### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const MyComponent = () => {
     * options?: {code: number[]}
     * 
     * the default code is: [38, 38, 40, 40, 37, 39, 37, 39, 66, 65, 13]
-    * [ up, up, down, down, left, right, left, right, a, b, enter ] 
+    * [ up, up, down, down, left, right, left, right, b, a, enter ] 
     */
     useKonami(() => {
         console.log('hi easter egg!');


### PR DESCRIPTION
swap the `a` and `b` in the readme